### PR TITLE
Match with `entry.function` instead of `entry.index`

### DIFF
--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -81,7 +81,7 @@ impl TdxVm {
         // patch cpuid
         for entry in cpuid_entries.as_mut_slice() {
             // mandatory patches for TDX based on XFAM values reported by TdxCapabilities
-            match entry.index {
+            match entry.function {
                 // XSAVE features and state-components
                 0xD => {
                     if entry.index == 0 {


### PR DESCRIPTION
When doing patches on the CPUID, match on the CPUID entry's `function` member instead of `index`.

Fixes: #9