### PR TITLE
Implement remaining functionality to boot TD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ kvm-ioctls = { git = "https://github.com/virtee/kvm-ioctls.git", branch = "main"
 libc = "0.2.155"
 uuid = "1.8.0"
 vmm-sys-util = "0.12.1"
+
+[patch.crates-io]
+kvm-bindings = { git = "https://www.github.com/rust-vmm/kvm-bindings.git", branch = "main"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ kvm-ioctls = { git = "https://github.com/virtee/kvm-ioctls.git", branch = "main"
 libc = "0.2.155"
 uuid = "1.8.0"
 vmm-sys-util = "0.12.1"
-
-[patch.crates-io]
-kvm-bindings = { git = "https://www.github.com/rust-vmm/kvm-bindings.git", branch = "main"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ rust-version = "1.71"
 
 [dependencies]
 bitflags = "2.4.2"
-kvm-bindings = "0.7.0"
-kvm-ioctls = "0.16.0"
+kvm-bindings = { git = "https://github.com/virtee/kvm-bindings.git", branch = "main", features = ["fam-wrappers"] }
+kvm-ioctls = { git = "https://github.com/virtee/kvm-ioctls.git", branch = "main" }
+libc = "0.2.155"
 uuid = "1.8.0"
 vmm-sys-util = "0.12.1"

--- a/src/launch/linux.rs
+++ b/src/launch/linux.rs
@@ -10,6 +10,7 @@ pub enum CmdId {
     GetCapabilities,
     InitVm,
     InitVcpu,
+    InitMemRegion,
 }
 
 /// Contains information for the sub-ioctl() command to be run. This is
@@ -230,4 +231,17 @@ impl Default for InitVm {
             cpuid_entries: [Default::default(); 256],
         }
     }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct TdxInitMemRegion {
+    /// Host physical address of the target page to be added to the TD
+    pub source_addr: u64,
+
+    /// Guest physical address to be mapped
+    pub gpa: u64,
+
+    /// Number of pages to be mapped
+    pub nr_pages: u64,
 }

--- a/src/launch/linux.rs
+++ b/src/launch/linux.rs
@@ -2,7 +2,7 @@
 
 use std::marker::PhantomData;
 
-pub const NR_CPUID_CONFIGS: usize = 12;
+pub const NR_CPUID_CONFIGS: usize = 24;
 
 /// Trust Domain eXtensions sub-ioctl() commands
 #[repr(u32)]

--- a/src/launch/linux.rs
+++ b/src/launch/linux.rs
@@ -11,6 +11,7 @@ pub enum CmdId {
     InitVm,
     InitVcpu,
     InitMemRegion,
+    FinalizeVm,
 }
 
 /// Contains information for the sub-ioctl() command to be run. This is

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -2,14 +2,14 @@
 
 mod linux;
 
-use kvm_bindings::{kvm_enable_cap, KVM_CAP_MAX_VCPUS, KVM_CAP_SPLIT_IRQCHIP};
+use kvm_bindings::{kvm_enable_cap, KVM_CAP_MAX_VCPUS};
 use linux::{Capabilities, Cmd, CmdId, CpuidConfig, InitVm, TdxError};
 
 use bitflags::bitflags;
 use kvm_ioctls::VmFd;
 
 // Defined in linux/arch/x86/include/uapi/asm/kvm.h
-pub const KVM_X86_TDX_VM: u64 = 2;
+pub const KVM_X86_TDX_VM: u64 = 5;
 
 /// Handle to the TDX VM file descriptor
 pub struct TdxVm {}
@@ -23,10 +23,6 @@ impl TdxVm {
             ..Default::default()
         };
         cap.args[0] = max_vcpus;
-        vm_fd.enable_cap(&cap).unwrap();
-
-        cap.cap = KVM_CAP_SPLIT_IRQCHIP;
-        cap.args[0] = 24;
         vm_fd.enable_cap(&cap).unwrap();
 
         cap.cap = kvm_bindings::KVM_CAP_X2APIC_API;

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -33,6 +33,10 @@ impl TdxVm {
         cap.args[0] = 24;
         vm_fd.enable_cap(&cap).unwrap();
 
+        cap.cap = kvm_bindings::KVM_CAP_X2APIC_API;
+        cap.args[0] = (1 << 0) | (1 << 1);
+        vm_fd.enable_cap(&cap).unwrap();
+
         Ok(Self { fd: vm_fd })
     }
 

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -117,6 +117,37 @@ impl TdxVm {
 
         Ok(())
     }
+
+    /// Encrypt a memory continuous region
+    pub fn init_mem_region(
+        &self,
+        gpa: u64,
+        nr_pages: u64,
+        attributes: u32,
+        source_addr: u64,
+    ) -> Result<(), TdxError> {
+        const TDVF_SECTION_ATTRIBUTES_MR_EXTEND: u32 = 1u32 << 0;
+        let mem_region = linux::TdxInitMemRegion {
+            source_addr,
+            gpa,
+            nr_pages,
+        };
+
+        let mut cmd: Cmd<linux::TdxInitMemRegion> = Cmd::from(CmdId::InitMemRegion, &mem_region);
+
+        // determines if we also extend the measurement
+        cmd.flags = if attributes & TDVF_SECTION_ATTRIBUTES_MR_EXTEND > 0 {
+            1
+        } else {
+            0
+        };
+
+        unsafe {
+            self.fd.encrypt_op(&mut cmd)?;
+        }
+
+        Ok(())
+    }
 }
 
 bitflags! {

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -7,7 +7,6 @@ use linux::{Capabilities, Cmd, CmdId, CpuidConfig, InitVm, TdxError};
 
 use bitflags::bitflags;
 use kvm_ioctls::{Kvm, VmFd};
-use std::arch::x86_64;
 
 // Defined in linux/arch/x86/include/uapi/asm/kvm.h
 const KVM_X86_TDX_VM: u64 = 2;
@@ -61,7 +60,7 @@ impl TdxVm {
     }
 
     /// Do additional VM initialization that is specific to Intel TDX
-    pub fn init_vm(&self, kvm_fd: &Kvm, caps: &TdxCapabilities) -> Result<(), TdxError> {
+    pub fn init_vm(&self, kvm_fd: &Kvm) -> Result<(), TdxError> {
         let cpuid = kvm_fd
             .get_supported_cpuid(kvm_bindings::KVM_MAX_CPUID_ENTRIES)
             .unwrap();
@@ -69,45 +68,6 @@ impl TdxVm {
 
         // resize to 256 entries to make sure that InitVm is 8KB
         cpuid_entries.resize(256, kvm_bindings::kvm_cpuid_entry2::default());
-
-        // hex for Ob1100000001011111111 based on the XSAVE state-components architecture
-        let xcr0_mask = 0x602ff;
-        // hex for 0b11111110100000000 based on the XSAVE state-components architecture
-        let xss_mask = 0x1FD00;
-
-        let xfam_fixed0 = caps.xfam.fixed0.bits();
-        let xfam_fixed1 = caps.xfam.fixed1.bits();
-
-        // patch cpuid
-        for entry in cpuid_entries.as_mut_slice() {
-            // mandatory patches for TDX based on XFAM values reported by TdxCapabilities
-            match entry.index {
-                // XSAVE features and state-components
-                0xD => {
-                    if entry.index == 0 {
-                        // XSAVE XCR0 LO
-                        entry.eax &= (xfam_fixed0 as u32) & (xcr0_mask as u32);
-                        entry.eax |= (xfam_fixed1 as u32) & (xcr0_mask as u32);
-                        // XSAVE XCR0 HI
-                        entry.edx &= ((xfam_fixed0 & xcr0_mask) >> 32) as u32;
-                        entry.edx |= ((xfam_fixed1 & xcr0_mask) >> 32) as u32;
-                    } else if entry.index == 1 {
-                        // XSAVE XCR0 LO
-                        entry.ecx &= (xfam_fixed0 as u32) & (xss_mask as u32);
-                        entry.ecx |= (xfam_fixed1 as u32) & (xss_mask as u32);
-                        // XSAVE XCR0 HI
-                        entry.edx &= ((xfam_fixed0 & xss_mask) >> 32) as u32;
-                        entry.edx |= ((xfam_fixed1 & xss_mask) >> 32) as u32;
-                    }
-                }
-                0x8000_0008 => {
-                    // host physical address bits supported
-                    let phys_bits = unsafe { x86_64::__cpuid(0x8000_0008).eax } & 0xff;
-                    entry.eax = (entry.eax & 0xffff_ff00) | (phys_bits & 0xff);
-                }
-                _ => (),
-            }
-        }
 
         let init_vm = InitVm::new(&cpuid_entries);
         let mut cmd: Cmd<InitVm> = Cmd::from(CmdId::InitVm, &init_vm);

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -148,6 +148,16 @@ impl TdxVm {
 
         Ok(())
     }
+
+    /// Complete measurement of the initial TD contents and mark it ready to run
+    pub fn finalize(&self) -> Result<(), TdxError> {
+        let mut cmd: Cmd<u64> = Cmd::from(CmdId::FinalizeVm, &0);
+        unsafe {
+            self.fd.encrypt_op(&mut cmd)?;
+        }
+
+        Ok(())
+    }
 }
 
 bitflags! {

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -22,3 +22,56 @@ fn launch() {
     let hob_section = tdvf::get_hob_section(&sections).unwrap();
     tdx_vcpu.init(hob_section.memory_address).unwrap();
 }
+
+/// Round number down to multiple
+pub fn align_down(n: usize, m: usize) -> usize {
+    n / m * m
+}
+
+/// Round number up to multiple
+pub fn align_up(n: usize, m: usize) -> usize {
+    align_down(n + m - 1, m)
+}
+
+/// Reserve a new memory region of the requested size to be used for maping from the given fd (if
+/// any)
+pub fn mmap_reserve(size: usize, fd: i32) -> *mut libc::c_void {
+    let mut flags = libc::MAP_PRIVATE;
+    flags |= libc::MAP_ANONYMOUS;
+    unsafe { libc::mmap(0 as _, size, libc::PROT_NONE, flags, fd, 0) }
+}
+
+/// Activate memory in a reserved region from the given fd (if any), to make it accessible.
+pub fn mmap_activate(
+    ptr: *mut libc::c_void,
+    size: usize,
+    fd: i32,
+    map_flags: u32,
+    map_offset: i64,
+) -> *mut libc::c_void {
+    let noreserve = map_flags & (1 << 3);
+    let readonly = map_flags & (1 << 0);
+    let shared = map_flags & (1 << 1);
+    let sync = map_flags & (1 << 2);
+    let prot = libc::PROT_READ | (if readonly == 1 { 0 } else { libc::PROT_WRITE });
+    let mut map_synced_flags = 0;
+    let mut flags = libc::MAP_FIXED;
+
+    flags |= if fd == -1 { libc::MAP_ANONYMOUS } else { 0 };
+    flags |= if shared >= 1 {
+        libc::MAP_SHARED
+    } else {
+        libc::MAP_PRIVATE
+    };
+    flags |= if noreserve >= 1 {
+        libc::MAP_NORESERVE
+    } else {
+        0
+    };
+
+    if shared >= 1 && sync >= 1 {
+        map_synced_flags = libc::MAP_SYNC | libc::MAP_SHARED_VALIDATE;
+    }
+
+    unsafe { libc::mmap(ptr, size, prot, flags | map_synced_flags, fd, map_offset) }
+}

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -6,22 +6,103 @@ use vmm_sys_util::*;
 use tdx::launch::{TdxVcpu, TdxVm};
 use tdx::tdvf;
 
+// `mov eax,1000h` will set the value in the register eax (and rax since they both share the bottom 32 bits) to 1000h
+// `jmp *%rax` will jump the program to the address that rax contains, which in this case will be 1000h
+const FIRMWARE: &[u8; 7] = &[
+    0xb8, 0x00, 0x10, 0x00, 0x00, // mov eax, 1000h
+    0xff, 0xe0, // jmp *%rax
+];
+
 #[test]
 fn launch() {
-    let mut kvm_fd = Kvm::new().unwrap();
+    const KVM_CAP_GUEST_MEMFD: u32 = 234;
+    const KVM_CAP_MEMORY_MAPPING: u32 = 236;
 
     // create vm
+    let mut kvm_fd = Kvm::new().unwrap();
     let tdx_vm = TdxVm::new(&kvm_fd, 100).unwrap();
-    let caps = tdx_vm.get_capabilities().unwrap();
-    let _ = tdx_vm.init_vm(&kvm_fd, &caps).unwrap();
+    let _caps = tdx_vm.get_capabilities().unwrap();
+    let _ = tdx_vm.init_vm(&kvm_fd).unwrap();
+
+    // get tdvf sections
+    let mut firmware = std::fs::File::open("/usr/share/edk2/ovmf/OVMF.inteltdx.fd").unwrap();
+    let sections = tdvf::parse_sections(&mut firmware).unwrap();
+    let hob_section = tdvf::get_hob_section(&sections).unwrap();
 
     // create vcpu
     let mut vcpufd = tdx_vm.fd.create_vcpu(10).unwrap();
     let tdx_vcpu = TdxVcpu::try_from((&mut vcpufd, &mut kvm_fd)).unwrap();
-    let mut firmware = std::fs::File::open("./tests/data/OVMF.inteltdx.fd").unwrap();
-    let sections = tdvf::parse_sections(&mut firmware).unwrap();
-    let hob_section = tdvf::get_hob_section(&sections).unwrap();
     tdx_vcpu.init(hob_section.memory_address).unwrap();
+
+    // map memory to guest
+    if !check_extension(KVM_CAP_GUEST_MEMFD) {
+        panic!("KVM_CAP_GUEST_MEMFD isn't supported, which is required by TDX");
+    }
+
+    // In TDX you cannot modify the registers directly since they are
+    // confidential. Therefore, if you want the VM to run custom code,
+    // you need to map it to the reset vector on the guest: 0xfffffff0.
+
+    // Start with the first 4k of memory (4G - 4k) as all 0s.
+    let firmware_code = &mut [0u8; 4096].to_vec();
+
+    // Map the firmware we want the VM to run on boot to the reset
+    // vector, which is at 4G - 16B (0xfffffff0).
+    for (idx, b) in FIRMWARE.iter().enumerate() {
+        firmware_code[4096 - 16 + idx] = *b;
+    }
+
+    let firmware_userspace = ram_mmap(firmware_code.len() as u64);
+    // (4 << 30) - 0x1000
+    let guest_addr = 0xfffff000u64;
+
+    // copy the firmware code into the memory allocated for `firmware_userspace`
+    let address_space: &mut [u8] = unsafe {
+        std::slice::from_raw_parts_mut(firmware_userspace as *mut u8, firmware_code.len())
+    };
+    address_space[..firmware_code.len()].copy_from_slice(&firmware_code[..]);
+    let firmware_userspace = address_space as *const [u8] as *const u8 as u64;
+
+    let gmem = kvm_bindings::kvm_create_guest_memfd {
+        size: firmware_code.len() as u64,
+        flags: 0,
+        reserved: [0; 6],
+    };
+
+    let gmem = tdx_vm.fd.create_guest_memfd(gmem).unwrap();
+    let region = kvm_bindings::kvm_userspace_memory_region2 {
+        slot: 0 as u32,
+        // KVM_MEM_GUEST_MEMFD
+        flags: 1 << 2,
+        guest_phys_addr: guest_addr,
+        memory_size: firmware_code.len() as u64,
+        userspace_addr: firmware_userspace,
+        guest_memfd_offset: 0,
+        guest_memfd: gmem as u32,
+        pad1: 0,
+        pad2: [0; 14],
+    };
+    unsafe {
+        tdx_vm.fd.set_user_memory_region2(region).unwrap();
+    }
+
+    let attr = kvm_bindings::kvm_memory_attributes {
+        address: guest_addr,
+        size: firmware_code.len() as u64,
+        // KVM_MEMORY_ATTRIBUTE_PRIVATE
+        attributes: 1 << 3,
+        flags: 0,
+    };
+    tdx_vm.fd.set_memory_attributes(attr).unwrap();
+
+    if check_extension(KVM_CAP_MEMORY_MAPPING) {
+        // TODO(jakecorrenti): the current CentOS SIG doesn't support the KVM_MEMORY_MAPPING or
+        // KVM_TDX_EXTEND_MEMORY ioctls, which is what we would typically use here.
+    } else {
+        tdx_vm
+            .init_mem_region(guest_addr, 1, 1, firmware_userspace)
+            .unwrap();
+    }
 }
 
 /// Round number down to multiple

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -20,7 +20,17 @@ fn launch() {
 
     // create vm
     let mut kvm_fd = Kvm::new().unwrap();
-    let vm_fd = kvm_fd.create_vm_with_type(tdx::launch::KVM_X86_TDX_VM).unwrap();
+    let vm_fd = kvm_fd
+        .create_vm_with_type(tdx::launch::KVM_X86_TDX_VM)
+        .unwrap();
+
+    let mut cap: kvm_bindings::kvm_enable_cap = kvm_bindings::kvm_enable_cap {
+        ..Default::default()
+    };
+    cap.cap = kvm_bindings::KVM_CAP_SPLIT_IRQCHIP;
+    cap.args[0] = 24;
+    vm_fd.enable_cap(&cap).unwrap();
+
     let tdx_vm = TdxVm::new(&vm_fd, 100).unwrap();
     let _caps = tdx_vm.get_capabilities(&vm_fd).unwrap();
     let cpuid = kvm_fd

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use kvm_ioctls::Kvm;
+use vmm_sys_util::*;
 
 use tdx::launch::{TdxVcpu, TdxVm};
 use tdx::tdvf;
@@ -114,4 +115,13 @@ pub fn ram_mmap(size: u64) -> u64 {
     }
 
     addr as u64
+}
+
+// NOTE(jakecorrenti): This IOCTL needs to get re-implemented manually. We need to check if KVM_CAP_MEMORY_MAPPING
+// and KVM_CAP_GUEST_MEMFD are supported on the host, but those values are not present in rust-vmm/kvm-{ioctls, bindings}
+ioctl_io_nr!(KVM_CHECK_EXTENSION, kvm_bindings::KVMIO, 0x03);
+
+fn check_extension(i: u32) -> bool {
+    let kvm = Kvm::new().unwrap();
+    (unsafe { ioctl::ioctl_with_val(&kvm, KVM_CHECK_EXTENSION(), i.into()) }) > 0
 }


### PR DESCRIPTION
Implements the `KVM_TDX_INIT_MEM_REGION` and `KVM_TDX_FINALIZE_VM` ioctls. 

The last four commits are changes that are the result of incorporating the library into Libkrun.