### PR TITLE
bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdx"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The VirTEE Project Developers <virtee-security@redhat.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
0.1.1 / 2026-05-19
==================

  * bump version to 0.1.1
  * Update versions of rust-vmm dependencies
  * launch: support dynamically determining nr_cpuid
  * tdvf: use `#[repr(C)]` on packed structs